### PR TITLE
Breaking the pipeline on policy violation, but keeping the report.

### DIFF
--- a/scaffolder-templates/quarkus-stssc-template/manifests/helm/build/templates/task-acs-image-check.yaml
+++ b/scaffolder-templates/quarkus-stssc-template/manifests/helm/build/templates/task-acs-image-check.yaml
@@ -59,11 +59,35 @@ spec:
       ./roxctl image check \
         $( [ "$(params.insecure-skip-tls-verify)" = "true" ] && \
         echo -n "--insecure-skip-tls-verify") \
-        -e "$(params.rox_central_endpoint)" --image "$IMAGE" --output json > $(workspaces.reports.path)/image-check
+        -e "$(params.rox_central_endpoint)" --image "$IMAGE" --output json > roxctl_image_check.json
+      roxctl_exit_code=$?
+      echo $roxctl_exit_code > $(workspaces.reports.path)/roxctl_exit_code
+      if [ "$roxctl_exit_code" -eq 0 ]; then
+        echo "Image check ok"
+      else
+        echo "Image check detected violation"
+      fi
+      
+      cat roxctl_image_check.json >  $(workspaces.reports.path)/image-check
+
   - image: 'quay.io/lrangine/crda-maven:11.0'
     name: report
     script: |
         #!/bin/sh
         cat $(workspaces.reports.path)/image-check
+
+  - image: registry.access.redhat.com/ubi8/ubi-minimal
+    name: break-on-violation
+    script: |
+        #!/bin/sh
+        roxctl_exit_code=$(<$(workspaces.reports.path)/roxctl_exit_code)
+        echo "roxctl return code is: $roxctl_exit_code"
+        if [ "$roxctl_exit_code" -eq 0 ]; then
+          echo "roxctl image check finished successfully"
+        else
+          echo "Policy violation or roxctl failure - breaking the pipeline!"
+          exit 1
+        fi
+        
   workspaces:
     - name: reports


### PR DESCRIPTION
## What does this PR do / why we need it

tl;dr: If an ACS policy is set to break the build, it will break the pipeline (good) but since the task stops here, it will not generate the report _WHY_ it failed (bad). 
This PR fixes it.

## Which issue(s) does this PR fix
1) The standard demo setup has the `Fixable Severity at least important` ACS policy set to "inform" .
![Default-policy-inform](https://github.com/user-attachments/assets/313280bb-8cf1-4010-906a-7aaae8e112cf)

2) If I change the policy to "enform and enforce" to demonstrate ACS capabilities...
![change_policy](https://github.com/user-attachments/assets/fe64d4e8-d902-419a-8279-dfde6be57083)

3) The build will fail, as expected
![enforce_breaks_build](https://github.com/user-attachments/assets/f170b46f-81cb-4a41-9fcd-ed66d5d18b1e)

4) But since the task broke at this point, it never reaches the "report" step and thus there is no report which policy broke the build (aka what the user can do about it)
![no_image_check_report](https://github.com/user-attachments/assets/4ed3a982-1e8b-425c-8084-8e1facadec95)

5) With this PR, the build still breaks
![enforce_still_breaks_build](https://github.com/user-attachments/assets/7e093950-6aa2-447a-8aaa-79a170df4009)

6) but now has the report that shows **WHY** it broke
![broken_build_report](https://github.com/user-attachments/assets/d41c1cef-bea2-45c9-a48e-818a2a9bedbc)


## How to test changes / Special notes to the reviewer

Testing: As shown above:
1) Create a component with the tssc-quarkus-template
2) Let the pipeline run
3) Expected result - pipeline succeeds, all report tabs available
4) Change the policy `Fixable Severity at least important` in ACS to "inform and enforce"
5) Re-run the pipeline (via commit or in the OCP console)
6) Expected result - pipeline fails at the `acs-image-check` task, but the report is still available. 




